### PR TITLE
pq_fetch_all should return 'false' if result set is empty

### DIFF
--- a/pgsql.cpp
+++ b/pgsql.cpp
@@ -981,6 +981,9 @@ static Variant HHVM_FUNCTION(pg_fetch_all, const Resource& result) {
     }
 
     int num_rows = res->getNumRows();
+    if (num_rows == 0) {
+        FAIL_RETURN;
+    }
 
     Array rows;
     for (int i = 0; i < num_rows; i++) {


### PR DESCRIPTION
If pg_fetch_all reveices an empty result set, I get a segfault and I have no idea why. This path resolves the issue and makes pg_fetch_all more compatible with PHP. My first pull request, hope I did it right...
