### PR TITLE
Clarify the prerequisites of the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is an implementation of the `pgsql` PHP extension for [HHVM][fb-hphp].
 
 ### Prerequisites
 
-This extension only requires the `libpq` library distributed with Postgres and HipHop VM itself.
+This extension only requires the HipHop VM itself and the `libpq` library distributed with Postgres.
 
 ### Pre-built versions
 


### PR DESCRIPTION
The original phrasing made it sound like libpq was distributed with both Postgres and HHVM. This change should make the intended interpretation more obvious.
