### PR TITLE
Handle errors on the `pg_execute` function properly.

### DIFF
--- a/pgsql.cpp
+++ b/pgsql.cpp
@@ -1164,6 +1164,9 @@ static Variant HHVM_FUNCTION(pg_execute, const Resource& connection, const Strin
     CStringArray str_array(params);
 
     PQ::Result res = conn->get().execPrepared(stmtname.data(), params.size(), str_array.data());
+    if (_handle_query_result("pg_execute", conn->get(), res)) {
+        FAIL_RETURN;
+    }
 
     PGSQLResult *pgres = newres<PGSQLResult>(conn, std::move(res));
 


### PR DESCRIPTION
Before this patch executing `pg_execute` always returned the statement object,
even on failure. This patch fixes this so it matches the specification of this
function as defined here:

```
http://php.net/manual/en/function.pg-execute.php
```

According to the README of this project, the `pg_execute` function should
behave in the same way as in the Zend implementation.
