### PR TITLE
Fixing strprintf to support two parallel statements

### DIFF
--- a/pdo_pgsql_statement.h
+++ b/pdo_pgsql_statement.h
@@ -60,9 +60,10 @@ namespace HPHP {
         long m_current_row;
 
         std::string strprintf(const char* format, ...){
-            va_list args;
+            va_list args, args_copy;
             va_start (args, format);
-            int size = vsnprintf(NULL, 0, format, args);
+            va_copy (args_copy, args);
+            int size = vsnprintf(NULL, 0, format, args_copy);
             auto buffer = std::unique_ptr<char[]>(new char[size+1]);
             if(vsnprintf((char*)buffer.get(), size+1, format, args) != size){
                 throw std::exception();


### PR DESCRIPTION
I, myself, am a C++ noob, so please double check this one thoroughly.

Without the va_copy the value of args after the first vsnprint is indeterminate according to the standard.
See http://stackoverflow.com/questions/10069597/regarding-vsnprintf-interview/10070606#10070606  or http://www.bailopan.net/blog/?p=30

I found this issue while having two prepared statements open, both having the same name and therefore the second one got rejected from the PostgreSQL server.