### PR TITLE
Added skip of second initialization of libcrypto and libssl

### DIFF
--- a/pgsql.cpp
+++ b/pgsql.cpp
@@ -580,6 +580,7 @@ void PGSQLConnectionPool::CloseFreeConnections()
 
 PGSQLConnectionPoolContainer::PGSQLConnectionPoolContainer()
     :m_pools() {
+    PQinitSSL(0);
 }
 
 


### PR DESCRIPTION
Hi PocketRent,

This patch is for 3.2.0 version.
During my work on the issue https://github.com/facebook/hhvm/issues/4165, I found that root cause of the described problem is a double initialization of libcrypto and libssl:
* one from hhvm itself(ext_openssl and hhvm/hphp/util/ssl-init.cpp)
* and second one from libpq

As it described in the issue, it leads to deadlock. I am able to reproduce this deadlock. Possible test case is running of  *pg_connect* and *openssl_random_pseudo_bytes* in parallel.

So the proposed solution is based on the following description of PQinitSSL method of libpq:
(Taken from here: http://www.postgresql.org/docs/9.2/static/libpq-ssl.html)
*If your application initializes libssl and/or libcrypto libraries and libpq is built with SSL support, you should call PQinitOpenSSL to tell libpq that the libssl and/or libcrypto libraries have been initialized by your application, so that libpq will not also initialize those libraries.*

Best regards,
Aleksei Mateosian