### PR TITLE
Compile and link the pgsql DSO against HHVM source 05Mar2015.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ Makefile
 CMakeLists.txt
 .*.s??
 *.so
+
+run-test
+install_manifest.txt

--- a/pdo_pgsql.cpp
+++ b/pdo_pgsql.cpp
@@ -11,8 +11,8 @@ PDOPgSql::PDOPgSql() : PDODriver("pgsql") {
     PQinitSSL(0);
 }
 
-PDOResource* PDOPgSql::createResourceImpl() {
-        return newres<PDOPgSqlResource>(std::make_shared<PDOPgSqlConnection>());
+SmartPtr<PDOResource> PDOPgSql::createResourceImpl() {
+        return makeSmartPtr<PDOPgSqlResource>(std::make_shared<PDOPgSqlConnection>());
 }
 
 

--- a/pdo_pgsql.h
+++ b/pdo_pgsql.h
@@ -7,7 +7,7 @@
 namespace HPHP {
 struct PDOPgSql : public PDODriver {
     PDOPgSql();
-    PDOResource* createResourceImpl() override;
+    virtual SmartPtr<PDOResource> createResourceImpl() override;
 };
 
 long pdo_attr_lval(const Array& options, int opt, long defaultValue);

--- a/pdo_pgsql_statement.cpp
+++ b/pdo_pgsql_statement.cpp
@@ -59,7 +59,7 @@ namespace HPHP {
         if(supports_placeholders != PDO_PLACEHOLDER_NONE && m_server->protocolVersion() > 2){
             named_rewrite_template = "$%d";
             String nsql;
-            int ret = pdo_parse_params(this, sql, nsql);
+            int ret = pdo_parse_params(sp_PDOStatement(this), sql, nsql);
             if(ret == 1){
                 // Query was rewritten
             } else if (ret == -1){

--- a/pgsql.cpp
+++ b/pgsql.cpp
@@ -1793,9 +1793,7 @@ public:
 
 }
 
-extern "C" Extension *getModule() {
-    return &s_pgsql_extension;
-}
+HHVM_GET_MODULE(pgsql);
 
 ///////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
This was done by cargo cult programming.

Use SmartPtrs.

Use macro HHVM_GET_MODULE(pgsql) as needed to export
function getModuleBuildInfo.