### PR TITLE
pg_fetch_all_columns should return false when result has no rows

### DIFF
--- a/pgsql.cpp
+++ b/pgsql.cpp
@@ -1321,6 +1321,10 @@ static Variant HHVM_FUNCTION(pg_fetch_all_columns, const Resource& result, int64
 
     int num_rows = res->getNumRows();
 
+    if (num_rows == 0) {
+        FAIL_RETURN;
+    }
+
     Array arr;
     for (int i = 0; i < num_rows; i++) {
         Variant field = res->getFieldVal(i, column);


### PR DESCRIPTION
This was causing problems for Moodle, as it expects false not null for any failed/empty results. It also seems to match the zend extension:

ext/pgsql/pgsql.c-2928- array_init(return_value);
ext/pgsql/pgsql.c-2929-
ext/pgsql/pgsql.c-2930- if ((pg_numrows = PQntuples(pgsql_result)) <= 0) {
ext/pgsql/pgsql.c-2931-         return;
ext/pgsql/pgsql.c-2932- }