### PR TITLE
Fixes for SmartPtr and pdo header locations in HHVM 3.8.x

### DIFF
--- a/pdo_pgsql.cpp
+++ b/pdo_pgsql.cpp
@@ -11,12 +11,12 @@ PDOPgSql::PDOPgSql() : PDODriver("pgsql") {
     PQinitSSL(0);
 }
 
-SmartPtr<PDOResource> PDOPgSql::createResourceImpl() {
-    return makeSmartPtr<PDOPgSqlResource>(std::make_shared<PDOPgSqlConnection>());
+req::ptr<PDOResource> PDOPgSql::createResourceImpl() {
+    return req::make<PDOPgSqlResource>(std::make_shared<PDOPgSqlConnection>());
 }
 
-SmartPtr<PDOResource> PDOPgSql::createResourceImpl(const sp_PDOConnection& conn) {
-    return makeSmartPtr<PDOPgSqlResource>(
+req::ptr<PDOResource> PDOPgSql::createResourceImpl(const sp_PDOConnection& conn) {
+    return req::make<PDOPgSqlResource>(
         std::dynamic_pointer_cast<PDOPgSqlConnection>(conn)
     );
 }

--- a/pdo_pgsql.h
+++ b/pdo_pgsql.h
@@ -2,13 +2,13 @@
 #define incl_HPHP_PDO_PGSQL_H_
 
 #include "hphp/runtime/base/type-string.h"
-#include "hphp/runtime/ext/pdo_driver.h"
+#include "hphp/runtime/ext/pdo/pdo_driver.h"
 
 namespace HPHP {
 struct PDOPgSql : public PDODriver {
     PDOPgSql();
-    virtual SmartPtr<PDOResource> createResourceImpl() override;
-    virtual SmartPtr<PDOResource> createResourceImpl(const sp_PDOConnection& conn) override;
+    virtual req::ptr<PDOResource> createResourceImpl() override;
+    virtual req::ptr<PDOResource> createResourceImpl(const sp_PDOConnection& conn) override;
 };
 
 long pdo_attr_lval(const Array& options, int opt, long defaultValue);

--- a/pdo_pgsql_connection.h
+++ b/pdo_pgsql_connection.h
@@ -1,7 +1,7 @@
 #ifndef incl_HPHP_PDO_PGSQL_CONNECTION_H_
 #define incl_HPHP_PDO_PGSQL_CONNECTION_H_
 
-#include "hphp/runtime/ext/pdo_driver.h"
+#include "hphp/runtime/ext/pdo/pdo_driver.h"
 #include "pq.h"
 
 #define PHP_PDO_PGSQL_CONNECTION_FAILURE_SQLSTATE "08006"

--- a/pdo_pgsql_resource.h
+++ b/pdo_pgsql_resource.h
@@ -1,7 +1,7 @@
 #ifndef incl_HPHP_PDO_PGSQL_RESOURCE_H_
 #define incl_HPHP_PDO_PGSQL_RESOURCE_H_
 
-#include "hphp/runtime/ext/pdo_driver.h"
+#include "hphp/runtime/ext/pdo/pdo_driver.h"
 #include "pdo_pgsql_connection.h"
 #include "pq.h"
 #include "stdarg.h"

--- a/pdo_pgsql_statement.h
+++ b/pdo_pgsql_statement.h
@@ -1,7 +1,7 @@
 #ifndef incl_HPHP_PDO_PGSQL_STATEMENT_H_
 #define incl_HPHP_PDO_PGSQL_STATEMENT_H_
 
-#include "hphp/runtime/ext/pdo_driver.h"
+#include "hphp/runtime/ext/pdo/pdo_driver.h"
 #include "pdo_pgsql_resource.h"
 #include "pq.h"
 #include "stdarg.h"


### PR DESCRIPTION
Fixes to let hhvm-pgsql build with hhvm changes:
"Rename SmartPtr<T> to req::ptr<T>" https://github.com/facebook/hhvm/commit/f4f799a566d8890efb2818f9b81b9562420088eb and
"shift pdo drivers to pdo folder" https://github.com/facebook/hhvm/commit/267ec48e261e695dd48eb4fbdf01c4cc6e9deb08#diff-dc329d8ef0ed2a80dd768d499f90725d