### PR TITLE
Remove newly added functions from missing list

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ There are a few differences from the standard Zend implementation.
   * `pg_meta_data`
   * `pg_put_line`
   * `pg_select`
-  * `pg_set_client_encoding`
-  * `pg_set_error_verbosity`
   * `pg_trace`
   * `pg_tty`
   * `pg_untrace`


### PR DESCRIPTION
the following were added in hhvm 3.15.2/3.16.0
- `pg_set_client_encoding`
- `pg_set_error_verbosity`